### PR TITLE
Fix input size to HRNet+OCR

### DIFF
--- a/tensorflow_advanced_segmentation_models/models/HRNetOCR.py
+++ b/tensorflow_advanced_segmentation_models/models/HRNetOCR.py
@@ -8,12 +8,14 @@ from ..backbones.tf_backbones import create_base_model
 # High Resolution Network + Object-Contextual Representations
 ################################################################################
 class HRNetOCR(tf.keras.Model):
-    def __init__(self, n_classes, filters=64, final_activation="softmax",
+    def __init__(self, n_classes, filters=64, height=None, width=None, final_activation="softmax",
                  spatial_ocr_scale=1, spatial_context_scale=1, **kwargs):
         super(HRNetOCR, self).__init__(**kwargs)
 
         self.n_classes = n_classes
         self.filters = filters
+        self.height = height
+        self.width = width
         self.final_activation = final_activation
         self.spatial_ocr_scale = spatial_ocr_scale
         self.spatial_context_scale = spatial_context_scale
@@ -139,5 +141,5 @@ class HRNetOCR(tf.keras.Model):
         return out
 
     def model(self):
-        x = tf.keras.layers.Input(shape=(HEIGHT, WIDTH, 3))
+        x = tf.keras.layers.Input(shape=(self.height, self.width, 3))
         return tf.keras.Model(inputs=[x], outputs=self.call(x))


### PR DESCRIPTION
Hi! Thanks very much for the repo, I've enjoyed playing around with it. 

Noticed that the new HRNet+OCR implementation does not allow for input image size to be set on initialisation. I propose the simple fix below which is in keeping with other models in the repo.

Issue: Model will not compile owing to "HEIGHT" and "WIDTH" not being initialised.
Fix: Add height and width as class attributes which set input layer dimensions in model class method.

Thoughts/alternatives welcomed. Cheers!